### PR TITLE
Allow FE to use descriptions from BE

### DIFF
--- a/src/Description/Description.js
+++ b/src/Description/Description.js
@@ -6,26 +6,30 @@ import { useEncounterState } from "../encounterState";
 const Description = () => {
   const player = usePlayerState();
   const { npc } = useEncounterState();
-  // starting string, can be changed according to player's last location
-  let description =
-    npc !== null ? `You see a ${npc.name}. ` : "You are in a grassy field. ";
+  let description = "";
+  if (npc !== null) {
+    description = npc.description;
+  } else {
+    // starting string, can be changed according to player's last location
+    description = "You are in a grassy field. ";
 
-  // array of arrays, first element of each subarray is a query into the player's stats,
-  // second element is a bit of info to add to the player's description
-  // ex: details[0] takes in the player's hp and maxhp and if the hp is less then half
-  // of the maxhp, gives back a "you are hurt" message.
-  const details = [
-    [({ hp, maxhp }) => hp < maxhp / 2, "You are hurt. "],
-    [({ attack }) => attack < 3, "You feel weak. "],
-    [({ defense }) => defense < 3, "You feel defenseless. "],
-    [({ name }) => !name, "You feel a loss of identity. "],
-  ];
+    // array of arrays, first element of each subarray is a query into the player's stats,
+    // second element is a bit of info to add to the player's description
+    // ex: details[0] takes in the player's hp and maxhp and if the hp is less then half
+    // of the maxhp, gives back a "you are hurt" message.
+    const details = [
+      [({ hp, maxhp }) => hp < maxhp / 2, "You are hurt. "],
+      [({ attack }) => attack < 3, "You feel weak. "],
+      [({ defense }) => defense < 3, "You feel defenseless. "],
+      [({ name }) => !name, "You feel a loss of identity. "],
+    ];
 
-  // if the query for each element in the details array returns true,
-  // add the relevant info to the description string. otherwise don't
-  description += details
-    .map(([query, info]) => (query(player) ? info : ""))
-    .join("");
+    // if the query for each element in the details array returns true,
+    // add the relevant info to the description string. otherwise don't
+    description += details
+      .map(([query, info]) => (query(player) ? info : ""))
+      .join("");
+  }
 
   return <p className="Description">{description}</p>;
 };


### PR DESCRIPTION
## Description

This change makes the description.js use the description pulled from the backend whenever an NPC is encountered.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    - this may be applicable? it updates the description, and it's no longer displaying the same text when an NPC is in the encounter state

## How Has This Been Tested?

manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
